### PR TITLE
cleanup tool ordering, move ownerships

### DIFF
--- a/ownership.md
+++ b/ownership.md
@@ -3,20 +3,22 @@
 This document details which team member covers which area.
 Besides transparency, this might come in handy in case of vacations or sickness.
 
-|                                                                                                                           | @codingjoe | @SebastianKapunkt | @mostafa-anm | @amureki | @bniwinski | @herrbenesch |
-|---------------------------------------------------------------------------------------------------------------------------|------------|-------------------|--------------|----------|------------|--------------|
-| [voiio.de](https://voiio.de)                                                                                              |            | x                 | (x)          |          |            |              |
-| javascript dependencies                                                                                                   |            | x                 | (x)          |          |            |              |
-| [style guide](styleguide.md)                                                                                              |            | x                 | (x)          |          |            |              |
-| JetBrains licenses                                                                                                        |            | x                 |              |          |            |              |
-| UI library                                                                                                                |            | x                 | (x)          |          |            |              |
-| first-level tech support                                                                                                  |            |                   | (x)          |          |            | x            |
-| Google Tag Manager                                                                                                        |            |                   | x            |          |            |              |
-| tech interviews                                                                                                           |            |                   |              |          |            | x            |
-| [Sentry](https://sentry.io)                                                                                               |            |                   |              | x        |            | (x)          |
-| tech meetups organization                                                                                                 |            |                   |              | x        |            |              |
-| [warehouse](https://data.voiio.de)                                                                                        |            |                   |              | x        |            |              |
-| python dependencies                                                                                                       |            |                   |              | x        |            |              |
-| [SSL certificates](https://github.com/voiio/voiio-platform/blob/main/docs/RUNBOOK.md#ssl--tls-certificates--lets-encrypt) |            |                   |              | x        |            |              |
-| bug reports via [Usersnap](https://usersnap.com)                                                                          |            |                   |              |          | x          |              |
-| product news (changelog)                                                                                                  |            |                   |              |          | x          | x            |
+|                                                                                                                           | @codingjoe | @SebastianKapunkt | @mostafa-anm | @amureki | @herrbenesch |
+|---------------------------------------------------------------------------------------------------------------------------|------------|-------------------|--------------|----------|--------------|
+| product news (changelog)                                                                                                  | x          |                   |              |          |              |
+| [voiio.de](https://voiio.de)                                                                                              |            | x                 |              |          |              |
+| javascript dependencies                                                                                                   |            | x                 |              |          |              |
+| [style guide](styleguide.md)                                                                                              |            | x                 |              |          |              |
+| JetBrains licenses                                                                                                        |            | x                 |              |          |              |
+| UI library                                                                                                                |            | x                 |              |          |              |
+| bug reports via [Usersnap](https://usersnap.com)                                                                          |            | x                 |              |          |              |
+| Storyboard via [Miro](https://miro.com/app/dashboard/)                                                                    |            | x                 |              |          |              |
+| Designs via [Figma](https://www.figma.com/files/team/1206963489982218455/voiio)                                           |            | x                 |              |          |              |
+| Google Tag Manager                                                                                                        |            |                   | x            |          |              |
+| [Sentry](https://sentry.io)                                                                                               |            |                   |              | x        |              |
+| tech meetups organization                                                                                                 |            |                   |              | x        |              |
+| [warehouse](https://data.voiio.de)                                                                                        |            |                   |              | x        |              |
+| python dependencies                                                                                                       |            |                   |              | x        |              |
+| [SSL certificates](https://github.com/voiio/voiio-platform/blob/main/docs/RUNBOOK.md#ssl--tls-certificates--lets-encrypt) |            |                   |              | x        |              |
+| first-level tech support                                                                                                  |            |                   |              |          | x            |
+| tech interviews                                                                                                           |            |                   |              |          | x            |

--- a/ownership.md
+++ b/ownership.md
@@ -3,22 +3,31 @@
 This document details which team member covers which area.
 Besides transparency, this might come in handy in case of vacations or sickness.
 
-|                                                                                                                           | @codingjoe | @SebastianKapunkt | @mostafa-anm | @amureki | @herrbenesch |
-|---------------------------------------------------------------------------------------------------------------------------|------------|-------------------|--------------|----------|--------------|
-| product news (changelog)                                                                                                  | x          |                   |              |          |              |
-| [voiio.de](https://voiio.de)                                                                                              |            | x                 |              |          |              |
-| javascript dependencies                                                                                                   |            | x                 |              |          |              |
-| [style guide](styleguide.md)                                                                                              |            | x                 |              |          |              |
-| JetBrains licenses                                                                                                        |            | x                 |              |          |              |
-| UI library                                                                                                                |            | x                 |              |          |              |
-| bug reports via [Usersnap](https://usersnap.com)                                                                          |            | x                 |              |          |              |
-| Storyboard via [Miro](https://miro.com/app/dashboard/)                                                                    |            | x                 |              |          |              |
-| Designs via [Figma](https://www.figma.com/files/team/1206963489982218455/voiio)                                           |            | x                 |              |          |              |
-| Google Tag Manager                                                                                                        |            |                   | x            |          |              |
-| [Sentry](https://sentry.io)                                                                                               |            |                   |              | x        |              |
-| tech meetups organization                                                                                                 |            |                   |              | x        |              |
-| [warehouse](https://data.voiio.de)                                                                                        |            |                   |              | x        |              |
-| python dependencies                                                                                                       |            |                   |              | x        |              |
-| [SSL certificates](https://github.com/voiio/voiio-platform/blob/main/docs/RUNBOOK.md#ssl--tls-certificates--lets-encrypt) |            |                   |              | x        |              |
-| first-level tech support                                                                                                  |            |                   |              |          | x            |
-| tech interviews                                                                                                           |            |                   |              |          | x            |
+|                                      | @codingjoe | @SebastianKapunkt | @mostafa-anm | @amureki | @herrbenesch |
+|--------------------------------------|------------|-------------------|--------------|----------|--------------|
+| product news (changelog)             | x          |                   |              |          |              |
+| [voiio.de][voiio.de]                 |            | x                 |              |          |              |
+| javascript dependencies              |            | x                 |              |          |              |
+| [style guide](styleguide.md)         |            | x                 |              |          |              |
+| JetBrains licenses                   |            | x                 |              |          |              |
+| UI library                           |            | x                 |              |          |              |
+| bug reports via [Usersnap][Usersnap] |            | x                 |              |          |              |
+| Storyboard via [Miro][Miro]          |            | x                 |              |          |              |
+| Designs via [Figma][Figma]           |            | x                 |              |          |              |
+| Google Tag Manager                   |            |                   | x            |          |              |
+| [Sentry][Sentry]                     |            |                   |              | x        |              |
+| tech meetups organization            |            |                   |              | x        |              |
+| [warehouse][warehouse]               |            |                   |              | x        |              |
+| python dependencies                  |            |                   |              | x        |              |
+| [SSL certificates][SSL_certificates] |            |                   |              | x        |              |
+| first-level tech support             |            |                   |              |          | x            |
+| tech interviews                      |            |                   |              |          | x            |
+
+
+[Figma]: https://www.figma.com/files/team/1206963489982218455/voiio
+[Miro]: https://miro.com/app/dashboard/
+[Sentry]: (https://sentry.io)
+[SSL_certificates]: https://github.com/voiio/voiio-platform/blob/main/docs/RUNBOOK.md#ssl--tls-certificates--lets-encrypt
+[Usersnap]: https://usersnap.com
+[voiio.de]: https://voiio.de
+[warehouse]: https://data.voiio.de


### PR DESCRIPTION
- I assigned the ownership of Figma, Miro and UserSnap to me
- removed Bianka from the view
- removed (x) - optional assignments
- Reordered tools (tools related to person first, and persons sorted by joining date)